### PR TITLE
fix: remove spinner from edit/upload button

### DIFF
--- a/i18n/messages.en.js
+++ b/i18n/messages.en.js
@@ -73,7 +73,6 @@ module.exports = {
     ],
     //* **** Spinner  */
 
-    spinner_loading_button: '  ',
     spinner_loading_file: 'Loading file...',
     spinner_loading_ladok: '',
 

--- a/i18n/messages.se.js
+++ b/i18n/messages.se.js
@@ -82,7 +82,6 @@ module.exports = {
 
     //* **** Spinner  */
 
-    spinner_loading_button: '  ',
     spinner_loading_file: 'Laddar upp filen...',
     spinner_loading_ladok: '',
 

--- a/public/js/app/components/AnalysisMenu.jsx
+++ b/public/js/app/components/AnalysisMenu.jsx
@@ -10,7 +10,6 @@ import {
   Button,
   Row,
   Col,
-  Spinner,
 } from 'reactstrap'
 
 import i18n from '../../../../i18n/index'
@@ -515,11 +514,6 @@ function AnalysisMenu(props) {
                 onClick={goToEditMode}
                 disabled={firstVisit}
               >
-                {ladokLoading && statisticsParams.ladokId.length && (
-                  <Spinner color="light" size="sm">
-                    {translate.spinner_loading_button}
-                  </Spinner>
-                )}
                 <div>{translate.btn_add_analysis}</div>
               </Button>
             </div>


### PR DESCRIPTION
I have removed a spinner from "edit/upload" button. I managed solve the bug of a '0' appearing when onclick, but after showing Anna she had the feedback that it would be a better idea to remove it all together. 