### PR TITLE
fix from testing of KUI-1265

### DIFF
--- a/public/css/kursutveckling-admin.scss
+++ b/public/css/kursutveckling-admin.scss
@@ -99,6 +99,18 @@
 .popover {
   .popover-header {
     @include typography.font-heading-xs;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 0 0 12px;
+
+    span {
+      padding: 0.5rem 0;
+    }
+    button {
+      flex-shrink: 0;
+    }
   }
 }
 

--- a/public/js/app/components/InfoButton.jsx
+++ b/public/js/app/components/InfoButton.jsx
@@ -1,16 +1,32 @@
 import React from 'react'
-import { UncontrolledPopover, PopoverHeader, PopoverBody } from 'reactstrap'
+import { Popover, PopoverHeader, PopoverBody } from 'reactstrap'
 
-const InfoButton = ({ id, textObj }) => (
-  <>
-    <button id={`button-to-activate-popup-${id}`} type="button" className="btn-info-modal" />
-    <UncontrolledPopover trigger="legacy" placement="auto" target={`button-to-activate-popup-${id}`}>
-      <PopoverHeader>{textObj.header}</PopoverHeader>
-      <PopoverBody>
-        <p>{textObj.body}</p>
-      </PopoverBody>
-    </UncontrolledPopover>
-  </>
-)
+const InfoButton = ({ id, textObj }) => {
+  const [isOpen, setIsOpen] = React.useState(false)
+
+  const toggle = () => setIsOpen(!isOpen)
+
+  return (
+    <>
+      <button id={`button-to-activate-popup-${id}`} type="button" className="btn-info-modal" onClick={toggle} />
+      <Popover
+        isOpen={isOpen}
+        trigger="legacy"
+        placement="auto"
+        toggle={toggle}
+        target={`button-to-activate-popup-${id}`}
+      >
+        <PopoverHeader>
+          <span>{textObj.header}</span>
+          <button className="kth-icon-button close" onClick={toggle} aria-label="Close" />
+        </PopoverHeader>
+
+        <PopoverBody>
+          <p>{textObj.body}</p>
+        </PopoverBody>
+      </Popover>
+    </>
+  )
+}
 
 export default InfoButton

--- a/server/controllers/adminCtrl.js
+++ b/server/controllers/adminCtrl.js
@@ -300,6 +300,7 @@ async function getIndex(req, res, next) {
       theme: 'student-web',
       proxyPrefix,
       description: i18n.messages[lang === 'en' ? 0 : 1].messages.title,
+      query: req.query,
     })
   } catch (err) {
     log.error('Error in getIndex', { error: err })

--- a/server/views/helpers/index.js
+++ b/server/views/helpers/index.js
@@ -1,9 +1,10 @@
 'use strict'
 const registerHeaderContentHelper = require('@kth/kth-node-web-common/lib/handlebars/helpers/headerContent')
-const { registerLanguageLinkHelper } = require('@kth/kth-node-web-common/lib/handlebars/helpers/languageLink')
 const log = require('@kth/log')
+const Handlebars = require('handlebars')
 const config = require('../../configuration').server
 const packageFile = require('../../../package.json')
+const i18n = require('../../../i18n')
 
 let { version } = packageFile
 
@@ -34,9 +35,24 @@ registerHeaderContentHelper({
  * packaged helpers in https://github.com/KTH/kth-node-web-common/tree/master/lib/handlebars/helpers
  * Those only need to be required. Docs embedded in source.
  */
-registerLanguageLinkHelper()
 require('@kth/kth-node-web-common/lib/handlebars/helpers/contentedit')
 
-const i18n = require('../../../i18n')
+/* Custom languageLinkWithQuery helper instead of the one from kth-node-web-common
+ * This custom helper supports keeping query params in the lang link which is needed
+ * in kursutveckling-admin-web as query param is used to decide if route is for editing
+ * or create new.
+ */
+Handlebars.registerHelper('languageLinkWithQuery', (lang, query) => {
+  const anchorMessageKey = lang === 'sv' ? 'language_link_lang_en' : 'language_link_lang_sv'
+  const label = i18n.message(anchorMessageKey, lang)
+  const hreflang = lang === 'sv' ? 'sv-SE' : 'en-US'
+
+  const searchParams = new URLSearchParams(query)
+  searchParams.set('l', lang === 'sv' ? 'en' : 'sv')
+  const link = `?${searchParams.toString()}`
+
+  return `<a class="kth-menu-item language" hreflang="${hreflang}" href="${link}">${label}</a>`
+})
+
 require('@kth/kth-node-web-common/lib/handlebars/helpers/createI18nHelper')(i18n)
 require('@kth/kth-node-web-common/lib/handlebars/helpers/safe')

--- a/server/views/partials/kthHeader.handlebars
+++ b/server/views/partials/kthHeader.handlebars
@@ -2,7 +2,7 @@
   <div class="kth-header__container">
     {{> headerLogotype }}
     <ul class="kth-header__tools">
-      <li>{{{languageLink lang}}}</li>
+      <li>{{{languageLinkWithQuery lang query}}}</li>
     </ul>
   </div>
 </header>


### PR DESCRIPTION
This PR fixes 2 issues found during testing:
1. Click on lang link doesn't display correct form in new language. 
  `kursutveckling-admin-web` uses url query string to display correct form and the standard languageLinkHelpers doesn't keep the query string. I've added a custom language link helper to fix this. I considered doing a PR to `kth-node-web-common` but decided that is not worth it since we only need this here and that `kursutveckling-admin-web` probably will be archived soon.
2. Popover triggered by info button doesn't have a close button as in other apps. I've added same solution as in `kursutveckling-web`